### PR TITLE
Bug: Currency Only recipes failed on item error

### DIFF
--- a/app/Services/RecipeManager.php
+++ b/app/Services/RecipeManager.php
@@ -94,7 +94,7 @@ class RecipeManager extends Service
                 }
             } else {
                 $items = $recipe->ingredients->where('ingredient_type', 'Item');
-                if ($items) throw new \Exception('Insufficient ingredients selected.');
+                if (count($items) > 0) throw new \Exception('Insufficient ingredients selected.');
             }
 
             // Debit the currency


### PR DESCRIPTION
Fixes bug where currency only recipes were failing because $items is never null but has a count of zero instead. 
(Apologies that I did not test this edge case the first time around).